### PR TITLE
Support for computations from pre-calculated replicates

### DIFF
--- a/resample/jackknife.py
+++ b/resample/jackknife.py
@@ -1,7 +1,7 @@
 """
 Jackknife resampling.
 """
-from typing import Callable, Generator, Sequence
+from typing import Callable, Generator, Sequence, Union
 
 import numpy as np
 
@@ -112,8 +112,8 @@ def bias(fn: Callable, sample: Sequence) -> np.ndarray:
     Parameters
     ----------
     fn : callable
-        Estimator. Can be any mapping ℝⁿ → ℝᵏ, where n is the sample size
-        and k is the length of the output array.
+        Estimator. Can be any mapping ℝⁿ → ℝᵏ, where n is the sample size and k is the
+        length of the output array.
     sample : array-like
         Original sample.
 
@@ -122,9 +122,31 @@ def bias(fn: Callable, sample: Sequence) -> np.ndarray:
     ndarray
         Jackknife estimate of bias (= expectation of estimator - true value).
     """
-    n = len(sample)
     theta = fn(sample)
-    mean_theta = np.mean(jackknife(fn, sample), axis=0)
+    resampled_thetas = jackknife(fn, sample)
+    return bias_from_precalculated(theta, resampled_thetas)
+
+
+def bias_from_precalculated(
+    theta: Union[float, np.ndarray], resampled_thetas: Sequence
+) -> np.ndarray:
+    """
+    Calculate jackknife estimate of bias from pre-calculated replicates.
+
+    Parameters
+    ----------
+    theta: float or array-like
+        Estimator applied to original sample.
+    resampled_thetas: Sequence
+        Estimator applied to jackknife replicates of original sample.
+
+    Returns
+    -------
+    ndarray
+        Jackknife estimate of bias (= expectation of estimator - true value).
+    """
+    n = len(resampled_thetas)
+    mean_theta = np.mean(resampled_thetas, axis=0)
     return (n - 1) * (mean_theta - theta)
 
 


### PR DESCRIPTION
As mentioned in #34, we need a way to allow computation from pre-calculated replicates.

My original idea was to reuse the existing interface to do this, but documentation and argument types then become a bit ugly, which was also @dsaxton 's concern.

We need to resolve this before publishing release 1.0, in case it has implications for our interface overhaul (not necessarily the case, but it could have).

To address the points raised, I drafted a solution here where the interface of the `bias` function in the `jackknife` module is left as is. In addition, there is a `bias_from_precalculated` (name to be refined), which accepts the pre-calculated replicates. Internally, `bias` calls `bias_from_precalculated`, of course.

@dsaxton Would that be a way to go for all functions? We need to introduce `X_from_precalculated` then for 
* bias
* bias_corrected
* variance
* confidence_interval

in both the jackknife and bootstrap modules.

This would be an acceptable solution for me, but whenever I see a common prefix/suffix, I am thinking of namespaces. I think it would be more organized to put these in a separate module, so that one can do
```
from resample.jackknife.precalculated import bias # the version in which you pass `theta` and `resampled_thetas`
```
or
```
from resample.jackknife import bias # the version in which you pass `fn` and `sample`
```

I think to make this work, we need to make `jackknife` and `bootstrap` into sub-packages, which then can have a sub-module `precalculated`. The directory structure would look like this.
```
resample
  __init__.py
  jackknife
     __init__.py
     precalculated.py
  bootstrap
     __init__.py
     precalculated.py
```