### PR TITLE
Add publish GitHub action

### DIFF
--- a/.github/workflows/publish-to-test-pypi.yml
+++ b/.github/workflows/publish-to-test-pypi.yml
@@ -2,7 +2,7 @@ name: Publish to PyPI
 
 on:
   push:
-    branches: [master, publish-to-pypi]
+    branches: [master]
 
 jobs:
   build-and-publish:


### PR DESCRIPTION
Trying to set this up to auto publish on commits to master (I think this would make sense in conjunction with the policy of making incremental commits to develop and then only committing to master for releases). ~https://github.com/resample-project/resample/pull/72 adds the pyproject.toml which I believe is required for pep517 to work and therefore this GitHub action as well (I decided to add the file separately).~ I've also added API tokens for PyPI and Test PyPI to this project's secrets.

@HDembinski I think that iminuit uses a similar process for releases, so can you review this when you get a chance?

Note: this is only publishing to test PyPI at the moment.

For reference code I'm largely lifting code from this guide: https://packaging.python.org/guides/publishing-package-distribution-releases-using-github-actions-ci-cd-workflows/