### PR TITLE
Add MANIFEST.in

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,2 @@
+include LICENSE
+include requirements.txt


### PR DESCRIPTION
This PR solves two issues:

- building from source is broken due to not including `requirements.txt` in source distribution. See issues in https://github.com/conda-forge/staged-recipes/pull/12451 and also:

```
$ pip install --no-binary=:all: resample
...
 FileNotFoundError: [Errno 2] No such file or directory: '/private/var/folders/ld/gx_9s3_n55g1dkhj59zjlxww0000gn/T/pip-install-sosjc3pf/resample/requirements.txt'
```

- license file is not included in the source distribution.