### PR TITLE
chore: ruff moved to astral-sh

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,7 +17,7 @@ repos:
   - id: trailing-whitespace
 
 # Ruff linter, replacement for flake8, isort, pydocstyle
-- repo: https://github.com/charliermarsh/ruff-pre-commit
+- repo: https://github.com/astral-sh/ruff-pre-commit
   rev: 'v0.0.270'
   hooks:
     - id: ruff


### PR DESCRIPTION
See https://github.com/scientific-python/cookie/pull/200.

Committed via https://github.com/asottile/all-repos