### PR TITLE
Remove bias estimation from bootstrap module

### DIFF
--- a/src/resample/_deprecated.py
+++ b/src/resample/_deprecated.py
@@ -1,0 +1,49 @@
+import warnings
+from numpy import VisibleDeprecationWarning
+from typing import TypeVar, Callable, Any
+
+T = TypeVar("T")
+
+
+class deprecated:
+    """Deprecate function of method."""
+
+    def __init__(self, reason: str):
+        """Initialize the decorator with a reason."""
+        self._reason = reason
+
+    def __call__(self, func: Callable[..., T]) -> Callable[..., T]:
+        """Wrap the target function or method."""
+
+        def decorated_func(*args: Any, **kwargs: Any) -> T:
+            warnings.warn(
+                f"{func.__name__} is deprecated: {self._reason}",
+                category=VisibleDeprecationWarning,
+                stacklevel=2,
+            )
+            return func(*args, **kwargs)
+
+        decorated_func.__name__ = func.__name__
+        decorated_func.__doc__ = "deprecated: " + self._reason
+        return decorated_func
+
+
+class deprecated_parameter:
+    def __init__(self, **replacements: str):
+        self._replacements = replacements
+
+    def __call__(self, func: Callable[..., T]) -> Callable[..., T]:
+        def decorated_func(*args: Any, **kwargs: Any) -> T:
+            for new, old in self._replacements.items():
+                if old in kwargs:
+                    warnings.warn(
+                        f"keyword {old!r} is deprecated, please use {new!r}",
+                        category=VisibleDeprecationWarning,
+                        stacklevel=2,
+                    )
+                    kwargs[new] = kwargs[old]
+                    del kwargs[old]
+            return func(*args, **kwargs)
+
+        decorated_func.__name__ = func.__name__
+        return decorated_func

--- a/src/resample/bootstrap.py
+++ b/src/resample/bootstrap.py
@@ -15,8 +15,6 @@ more efficient BCa method, see :func:`confidence_interval` for details.
 __all__ = [
     "resample",
     "bootstrap",
-    "bias",
-    "bias_corrected",
     "variance",
     "confidence_interval",
 ]
@@ -40,6 +38,7 @@ from scipy import stats
 from . import _util
 from .empirical import quantile_function_gen
 from .jackknife import jackknife
+from ._deprecated import deprecated
 
 
 def resample(
@@ -286,6 +285,10 @@ def bootstrap(
     return np.array([fn(x) for x in gen])
 
 
+@deprecated(
+    "bootstrap.bias is deprecated and will be removed in a future revision, "
+    "use jackknife.bias instead"
+)
 def bias(
     fn: Callable[..., np.ndarray],
     sample: "ArrayLike",
@@ -346,6 +349,10 @@ def bias(
     return np.mean(thetas, axis=0) - population_theta
 
 
+@deprecated(
+    "bootstrap.bias is deprecated and will be removed in a future revision, "
+    "use jackknife.bias instead"
+)
 def bias_corrected(
     fn: Callable[..., np.ndarray],
     sample: "ArrayLike",

--- a/tests/test_bootstrap.py
+++ b/tests/test_bootstrap.py
@@ -6,8 +6,6 @@ from scipy import stats
 
 from resample.bootstrap import (
     _fit_parametric_family,
-    bias,
-    bias_corrected,
     bootstrap,
     confidence_interval,
     resample,
@@ -214,9 +212,7 @@ def test_bootstrap_2d_balanced(rng):
     assert_allclose(mean(data), mean(r))
 
 
-@pytest.mark.parametrize(
-    "action", [bootstrap, bias, bias_corrected, variance, confidence_interval]
-)
+@pytest.mark.parametrize("action", [bootstrap, variance, confidence_interval])
 def test_bootstrap_several_args(action):
     x = [1, 2, 3]
     y = [4, 5, 6]
@@ -288,60 +284,6 @@ def test_bca_confidence_interval_bounded_estimator(ci_method, rng):
     data = (-3, -2, -1)
     ci = confidence_interval(fn, data, ci_method=ci_method, size=5, random_state=rng)
     assert_allclose((0.0, 0.0), ci)
-
-
-@pytest.mark.parametrize("method", NON_PARAMETRIC)
-def test_bias_on_unbiased(method, rng):
-    data = (0, 1, 2, 3)
-    r = bias(np.mean, data, method=method, random_state=rng)
-
-    if method == "balanced":
-        # bias is exactly zero for linear functions with the balanced bootstrap
-        assert r == 0
-    else:
-        # bias is not exactly zero for ordinary bootstrap
-        assert r == pytest.approx(0)
-
-
-@pytest.mark.parametrize("method", NON_PARAMETRIC)
-def test_bias_on_biased(method, rng):
-    def biased(x):
-        return np.var(x, ddof=0)
-
-    data = np.arange(100)
-    bad = biased(data)
-    correct = np.var(data, ddof=1)
-
-    r = bias(biased, data, method=method, size=10000, random_state=rng)
-    sample_bias = bad - correct
-    assert r == pytest.approx(sample_bias, rel=0.05)
-
-
-@pytest.mark.parametrize("method", NON_PARAMETRIC)
-def test_bias_on_biased_2(method, rng):
-    def biased(x):
-        n = len(x)
-        return (np.sum(x) + 2) / n
-
-    data = np.arange(100)
-    bad = biased(data)
-    correct = np.mean(data)
-
-    r = bias(biased, data, method=method, size=10000, random_state=rng)
-    sample_bias = bad - correct
-    assert r == pytest.approx(sample_bias, rel=0.1)
-
-
-@pytest.mark.parametrize("method", NON_PARAMETRIC)
-def test_bias_corrected(method, rng):
-    def fn(x):
-        return np.var(x, ddof=0)
-
-    data = np.arange(100)
-    correct = np.var(data, ddof=1)
-
-    r = bias_corrected(fn, data, size=10000, method=method, random_state=rng)
-    assert r == pytest.approx(correct, rel=0.001)
 
 
 @pytest.mark.parametrize("method", NON_PARAMETRIC)


### PR DESCRIPTION
`bootstrap.bias` and `bootstrap.bias_corrected` are deprecated.

The bias estimation with the bootstrap seem to work in our tests, but it is not something that people in the field do, and there is no proof that this is the proper way.

To be on the safe side, we should not offer this. People should use the jacknife for bias correction.