### PR TITLE
ci: macos-latest is changing to macos-14 ARM runners

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,14 +16,14 @@ jobs:
 
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        os: [ubuntu-latest, macos-13, windows-latest]
         include:
           # version number must be string, otherwise 3.10 becomes 3.1
           - os: windows-latest
             python-version: "3.12"
           - os: ubuntu-latest
             python-version: "3.10"
-          - os: macos-latest
+          - os: macos-13
             python-version: "3.8"
       fail-fast: false
     steps:


### PR DESCRIPTION
Committed via https://github.com/asottile/all-repos