### PR TITLE
Replace deprecation warnings

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -70,7 +70,4 @@ addopts = "--doctest-modules --strict-config --strict-markers -q -ra --ff"
 testpaths = ["src/resample", "tests"]
 log_cli_level = "INFO"
 xfail_strict = true
-filterwarnings = [
-    "error::DeprecationWarning",
-    "error::numpy.VisibleDeprecationWarning",
-]
+filterwarnings = ["error::DeprecationWarning", "error::FutureWarning"]

--- a/src/resample/bootstrap.py
+++ b/src/resample/bootstrap.py
@@ -153,12 +153,10 @@ def resample(
         if not isinstance(args[0], Collection):
             import warnings
 
-            from numpy import VisibleDeprecationWarning
-
             warnings.warn(
                 "Calling resample with positional instead of keyword parameters is "
                 "deprecated",
-                VisibleDeprecationWarning,
+                FutureWarning,
             )
             kwargs: Dict[str, Any] = {
                 "size": size,
@@ -434,12 +432,10 @@ def confidence_interval(
     if args and not isinstance(args[0], Collection):
         import warnings
 
-        from numpy import VisibleDeprecationWarning
-
         warnings.warn(
             "Calling confidence_interval with positional instead of keyword "
             "arguments is deprecated",
-            VisibleDeprecationWarning,
+            FutureWarning,
         )
 
         if len(args) == 1:

--- a/src/resample/jackknife.py
+++ b/src/resample/jackknife.py
@@ -92,12 +92,10 @@ def resample(
         if not isinstance(args[0], Collection):
             import warnings
 
-            from numpy import VisibleDeprecationWarning
-
             warnings.warn(
                 "Calling resample with positional instead of keyword arguments is "
                 "deprecated",
-                VisibleDeprecationWarning,
+                FutureWarning,
             )
             if len(args) == 1:
                 (copy,) = args

--- a/src/resample/permutation.py
+++ b/src/resample/permutation.py
@@ -150,8 +150,7 @@ def usp(
 
     if method == "shuffle":
         warnings.warn(
-            "method 'shuffle' is deprecated, please use 'boyett'",
-            np.VisibleDeprecationWarning,
+            "method 'shuffle' is deprecated, please use 'boyett'", FutureWarning
         )
         method = "boyett"
 

--- a/tests/test_bootstrap.py
+++ b/tests/test_bootstrap.py
@@ -309,57 +309,57 @@ def test_covariance(method, rng):
 
 def test_resample_deprecation(rng):
     data = [1, 2, 3]
-    from numpy import VisibleDeprecationWarning
+    from numpy import FutureWarning
 
-    with pytest.warns(VisibleDeprecationWarning):
+    with pytest.warns(FutureWarning):
         r = list(resample(data, 10))
         assert np.shape(r) == (10, 3)
 
-    with pytest.warns(VisibleDeprecationWarning):
+    with pytest.warns(FutureWarning):
         resample(data, 10, "balanced")
 
-    with pytest.warns(VisibleDeprecationWarning):
+    with pytest.warns(FutureWarning):
         with pytest.raises(ValueError):
             resample(data, 10, "foo")
 
-    with pytest.warns(VisibleDeprecationWarning):
+    with pytest.warns(FutureWarning):
         resample(data, 10, "balanced", [1, 1, 2])
 
-    with pytest.warns(VisibleDeprecationWarning):
+    with pytest.warns(FutureWarning):
         with pytest.raises(ValueError):
             resample(data, 10, "balanced", [1, 1])
 
-    with pytest.warns(VisibleDeprecationWarning):
+    with pytest.warns(FutureWarning):
         resample(data, 10, "balanced", [1, 1, 2], rng)
 
-    with pytest.warns(VisibleDeprecationWarning):
+    with pytest.warns(FutureWarning):
         resample(data, 10, "balanced", [1, 1, 2], 1)
 
-    with pytest.warns(VisibleDeprecationWarning):
+    with pytest.warns(FutureWarning):
         with pytest.raises(TypeError):
             resample(data, 10, "balanced", [1, 1, 2], 1.3)
 
-    with pytest.warns(VisibleDeprecationWarning):
+    with pytest.warns(FutureWarning):
         with pytest.raises(ValueError):  # too many arguments
             resample(data, 10, "balanced", [1, 1, 2], 1, 2)
 
 
 def test_confidence_interval_deprecation(rng):
-    from numpy import VisibleDeprecationWarning
+    from numpy import FutureWarning
 
     d = [1, 2, 3]
-    with pytest.warns(VisibleDeprecationWarning):
+    with pytest.warns(FutureWarning):
         r = confidence_interval(np.mean, d, 0.6, random_state=1)
     assert_equal(r, confidence_interval(np.mean, d, cl=0.6, random_state=1))
 
-    with pytest.warns(VisibleDeprecationWarning):
+    with pytest.warns(FutureWarning):
         r = confidence_interval(np.mean, d, 0.6, "percentile", random_state=1)
     assert_equal(
         r,
         confidence_interval(np.mean, d, cl=0.6, ci_method="percentile", random_state=1),
     )
 
-    with pytest.warns(VisibleDeprecationWarning):
+    with pytest.warns(FutureWarning):
         with pytest.raises(ValueError):
             confidence_interval(np.mean, d, 0.6, "percentile", 1)
 

--- a/tests/test_bootstrap.py
+++ b/tests/test_bootstrap.py
@@ -309,7 +309,6 @@ def test_covariance(method, rng):
 
 def test_resample_deprecation(rng):
     data = [1, 2, 3]
-    from numpy import FutureWarning
 
     with pytest.warns(FutureWarning):
         r = list(resample(data, 10))
@@ -345,8 +344,6 @@ def test_resample_deprecation(rng):
 
 
 def test_confidence_interval_deprecation(rng):
-    from numpy import FutureWarning
-
     d = [1, 2, 3]
     with pytest.warns(FutureWarning):
         r = confidence_interval(np.mean, d, 0.6, random_state=1)

--- a/tests/test_jackknife.py
+++ b/tests/test_jackknife.py
@@ -117,14 +117,13 @@ def test_resample_several_args_incompatible_keywords():
 
 def test_resample_deprecation():
     data = [1, 2, 3]
-    from numpy import VisibleDeprecationWarning
 
-    with pytest.warns(VisibleDeprecationWarning):
+    with pytest.warns(FutureWarning):
         r = list(resample(data, False))
 
     assert_equal(r, list(resample(data, copy=False)))
 
-    with pytest.warns(VisibleDeprecationWarning):
+    with pytest.warns(FutureWarning):
         with pytest.raises(ValueError):  # too many arguments
             resample(data, True, 1)
 

--- a/tests/test_permutation.py
+++ b/tests/test_permutation.py
@@ -239,7 +239,7 @@ def test_usp_bad_input():
 def test_usp_deprecrated():
     w = [[1, 2, 3], [4, 5, 6]]
     r1 = perm.usp(w, method="boyett", size=100, random_state=1)
-    with pytest.warns(np.VisibleDeprecationWarning):
+    with pytest.warns(FutureWarning):
         r2 = perm.usp(w, method="shuffle", size=100, random_state=1)
     assert r1.statistic == r2.statistic
 


### PR DESCRIPTION
The VisibileDeprecationWarning from numpy is replaced with the builtin FutureWarning.