### PR TITLE
tests: newshape deprecated in favor of shape

### DIFF
--- a/tests/test_bootstrap.py
+++ b/tests/test_bootstrap.py
@@ -182,7 +182,7 @@ def test_resample_3d_parametric_normal_raises():
 
 
 def test_resample_equal_along_axis():
-    data = np.reshape(np.tile([0, 1, 2], 3), newshape=(3, 3))
+    data = np.reshape(np.tile([0, 1, 2], 3), (3, 3))
     for b in resample(data, size=2):
         assert_equal(data, b)
 


### PR DESCRIPTION
DeprecationWarning: `newshape` keyword argument is deprecated, use `shape=...` or pass shape positionally instead. (deprecated in NumPy 2.1)

The only way to support old versions of NumPy is to pass positionally.